### PR TITLE
Remove whitespace tokenizer

### DIFF
--- a/config/search_scheme.json
+++ b/config/search_scheme.json
@@ -5,14 +5,6 @@
       "number_of_shards": 5,
       "analysis": {
         "analyzer": {
-          "analyzer_whitespace_token": {
-            "type": "custom",
-            "tokenizer": "whitespace",
-            "filter": [
-              "lowercase",
-              "filter_ascii_folding"
-            ]
-          },
            "analyzer_keyword_token_sort": {
             "type": "custom",
             "tokenizer": "keyword",


### PR DESCRIPTION
This PR removes the `whitespace` `tokenizer` to improve elasticsearch searches by making it not search individual words for multi-word searches.