### PR TITLE
Set replica sets to 0 and set number of shards to 1

### DIFF
--- a/config/search_scheme.json
+++ b/config/search_scheme.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "index": {
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "number_of_shards": 1,
       "analysis": {
         "analyzer": {
@@ -91,8 +91,8 @@
             "index": "false"
           },
           "corporate_name": {
-            "type": "keyword",
-            "index": "false"
+            "type": "text",
+            "index": "true"
           },
           "corporate_name_start": {
             "type": "text",

--- a/config/search_scheme.json
+++ b/config/search_scheme.json
@@ -1,8 +1,8 @@
 {
   "settings": {
     "index": {
-      "number_of_replicas": 3,
-      "number_of_shards": 5,
+      "number_of_replicas": 0,
+      "number_of_shards": 1,
       "analysis": {
         "analyzer": {
           "analyzer_whitespace_token": {	


### PR DESCRIPTION
According to Elasticsearch documentation having replica sets and having multiple shards results in scores that are not consistent across replica sets and shards. This causes Elasticsearch to return different data for the same search over multiple queries. https://www.elastic.co/guide/en/elasticsearch/reference/current/consistent-scoring.html