### PR TITLE
Integrate with the Alpha Key Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ lint.txt
 
 # Mac files
 .DS_Store
+
+# Package management files
+go.mod
+go.sum

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,9 @@ lint: GO111MODULE=off
 lint:
 	go get github.com/golang/lint/golint
 	golint ./... > $(lint_output)
+
+.PHONY: convey
+convey: GO111MODULE=off
+convey:
+	go get github.com/smartystreets/goconvey
+	goconvey

--- a/config/search_scheme.json
+++ b/config/search_scheme.json
@@ -5,13 +5,13 @@
       "number_of_shards": 5,
       "analysis": {
         "analyzer": {
-          "analyzer_whitespace_token": {	
-            "type": "custom",	
-            "tokenizer": "whitespace",	
-            "filter": [	
-              "lowercase",	
-              "filter_ascii_folding"	
-            ]	
+          "analyzer_whitespace_token": {
+            "type": "custom",
+            "tokenizer": "whitespace",
+            "filter": [
+              "lowercase",
+              "filter_ascii_folding"
+            ]
           },
           "analyzer_keyword_token_sort": {
             "type": "custom",
@@ -21,9 +21,9 @@
               "char_filter_remove_special_characters"
               ],
             "filter": [
-              "lowercase", 
-              "filter_ascii_folding", 
-              "trim", 
+              "lowercase",
+              "filter_ascii_folding",
+              "trim",
               "filter_whitespace_remove"
             ]
           },
@@ -31,7 +31,7 @@
             "type": "custom",
             "tokenizer": "edge_ngram_tokenizer",
             "filter": [
-              "lowercase", 
+              "lowercase",
               "filter_ascii_folding"
             ]
           }
@@ -93,6 +93,14 @@
           "corporate_name": {
             "type": "keyword",
             "index": "false"
+          },
+          "alpha_key": {
+            "type": "text",
+            "index": "true"
+          },
+          "ordered_alpha_key": {
+            "type": "text",
+            "index": "true"
           },
           "corporate_name_start": {
             "type": "text",

--- a/datastructures/alpha.go
+++ b/datastructures/alpha.go
@@ -1,0 +1,12 @@
+package datastructures
+
+// AlphaKey holds data returned by the alpha key service
+type AlphaKey struct {
+	SameAsAlphaKey  string `json:"sameAsAlphaKey"`
+	OrderedAlphaKey string `json:"orderedAlphaKey"`
+}
+
+// CompanyName holds the name of a company to be sent to the alpha key service
+type CompanyName struct {
+	Name string `json:"name"`
+}

--- a/datastructures/elastic.go
+++ b/datastructures/elastic.go
@@ -17,6 +17,8 @@ type EsItem struct {
 	CorporateNameStart  string `json:"corporate_name_start"`
 	CorporateNameEnding string `json:"corporate_name_ending,omitempty"`
 	RecordType          string `json:"record_type"`
+	AlphaKey            string `json:"alpha_key"`
+	OrderedAlphaKey     string `json:"ordered_alpha_key"`
 }
 
 // EsLinks holds a set of links relevant to an EsCompany

--- a/eshttp/eshttp.go
+++ b/eshttp/eshttp.go
@@ -2,6 +2,7 @@ package eshttp
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 
@@ -13,6 +14,7 @@ const applicationJSON = "application/json"
 // Client provides an interface with which to communicate with Elastic Search by way of HTTP requests
 type Client interface {
 	SubmitBulkToES(bulk []byte, companyNumbers []byte, esDestURL string, esDestIndex string) ([]byte, error)
+	GetAlphaKeys(companyNames []byte, alphaKeyURL string) ([]byte, error)
 }
 
 // ClientImpl provides a concrete implementation of the Client interface
@@ -42,7 +44,9 @@ func NewClientWithRequester(writer write.Writer, requester Requester) Client {
 // SubmitBulkToES uses an HTTP post request to submit data to Elastic Search
 func (c *ClientImpl) SubmitBulkToES(bulk []byte, companyNumbers []byte, esDestURL string, esDestIndex string) ([]byte, error) {
 
-	r, err := c.r.PostBulkToElasticSearch(bulk, esDestURL, esDestIndex)
+	uri := fmt.Sprintf("%s/%s/_bulk", esDestURL, esDestIndex)
+
+	r, err := c.r.Post(bulk, uri)
 	if err != nil {
 		c.w.LogPostError(string(companyNumbers))
 		log.Printf("error posting request %s: data %s", err, string(bulk))
@@ -65,6 +69,33 @@ func (c *ClientImpl) SubmitBulkToES(bulk []byte, companyNumbers []byte, esDestUR
 		c.w.LogUnexpectedResponse(string(companyNumbers))
 		log.Printf("unexpected put response %s: data %s", r.Status, string(bulk))
 		return nil, errors.New("invalid response")
+	}
+
+	return b, err
+}
+
+// GetAlphaKeys performs a POST request to fetch alpha keys for a given set of company names
+func (c *ClientImpl) GetAlphaKeys(companyNames []byte, alphaKeyURL string) ([]byte, error) {
+
+	uri := fmt.Sprintf("%s/alphakey-bulk", alphaKeyURL)
+
+	r, err := c.r.Post(companyNames, uri)
+	if err != nil {
+		c.w.LogAlphaKeyErrors(string(companyNames))
+		log.Printf("error fetching alpha keys %s: data %s", err, string(companyNames))
+		return nil, err
+	}
+
+	defer func() {
+		err = r.Body.Close()
+		if err != nil {
+			log.Fatalf("failed to close response body after fetching alpha keys: %s", err)
+		}
+	}()
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
 	}
 
 	return b, err

--- a/eshttp/mock_requester.go
+++ b/eshttp/mock_requester.go
@@ -30,17 +30,17 @@ func (m *MockRequester) EXPECT() *MockRequesterMockRecorder {
 	return m.recorder
 }
 
-// PostBulkToElasticSearch mocks base method
-func (m *MockRequester) PostBulkToElasticSearch(arg0 []byte, arg1 string, arg2 string) (*http.Response, error) {
+// Post mocks base method
+func (m *MockRequester) Post(arg0 []byte, arg1 string) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostBulkToElasticSearch", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Post", arg0, arg1)
 	ret0, _ := ret[0].(*http.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PostBulkToElasticSearch indicates an expected call of PostBulkToElasticSearch
-func (mr *MockRequesterMockRecorder) PostBulkToElasticSearch(arg0 interface{}, arg1 interface{}, arg2 interface{}) *gomock.Call {
+// Post indicates an expected call of Post
+func (mr *MockRequesterMockRecorder) Post(arg0 interface{}, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBulkToElasticSearch", reflect.TypeOf((*MockRequester)(nil).PostBulkToElasticSearch), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockRequester)(nil).Post), arg0, arg1)
 }

--- a/eshttp/request.go
+++ b/eshttp/request.go
@@ -7,7 +7,7 @@ import (
 
 // Requester provides an interface by which to execute HTTP requests
 type Requester interface {
-	PostBulkToElasticSearch(bulk []byte, esDestURL string, esDestIndex string) (*http.Response, error)
+	Post(body []byte, uri string) (*http.Response, error)
 }
 
 // Request provides a concrete implementation of the Requester interface
@@ -19,8 +19,8 @@ func NewRequester() Requester {
 	return &Request{}
 }
 
-// PostBulkToElasticSearch posts a 'bulk' to Elastic Search
-func (req *Request) PostBulkToElasticSearch(bulk []byte, esDestURL string, esDestIndex string) (*http.Response, error) {
+// Post performs a POST request, using a provided body, against a given uri
+func (req *Request) Post(body []byte, uri string) (*http.Response, error) {
 
-	return http.Post(esDestURL+"/"+esDestIndex+"/_bulk", applicationJSON, bytes.NewReader(bulk))
+	return http.Post(uri, applicationJSON, bytes.NewReader(body))
 }

--- a/write/mock_writer.go
+++ b/write/mock_writer.go
@@ -76,3 +76,15 @@ func (mr *MockWriterMockRecorder) LogMissingCompanyName(arg0 interface{}) *gomoc
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogMissingCompanyName", reflect.TypeOf((*MockWriter)(nil).LogMissingCompanyName), arg0)
 }
+
+// LogAlphaKeyErrors mocks base method
+func (m *MockWriter) LogAlphaKeyErrors(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "LogAlphaKeyErrors", arg0)
+}
+
+// LogAlphaKeyErrors indicates an expected call of LogAlphaKeyErrors
+func (mr *MockWriterMockRecorder) LogAlphaKeyErrors(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogAlphaKeyErrors", reflect.TypeOf((*MockWriter)(nil).LogAlphaKeyErrors), arg0)
+}

--- a/write/write.go
+++ b/write/write.go
@@ -9,6 +9,7 @@ const (
 	postRequestErrors  = "errors/postRequestErrors.txt"
 	unexpectedResponse = "errors/unexpectedResponse.txt"
 	missingCompanyName = "errors/missingCompanyName.txt"
+	alphaKeyErrors     = "errors/alphaKeyErrors.txt"
 )
 
 // Writer provides an interface by which to write error messages to log files
@@ -16,6 +17,7 @@ type Writer interface {
 	LogPostError(msg string)
 	LogUnexpectedResponse(msg string)
 	LogMissingCompanyName(msg string)
+	LogAlphaKeyErrors(msg string)
 	Close()
 }
 
@@ -24,6 +26,7 @@ type Write struct {
 	pe  *os.File
 	ur  *os.File
 	mcn *os.File
+	ake *os.File
 }
 
 // NewWriter returns a concrete implementation of the Writer interface
@@ -44,10 +47,16 @@ func NewWriter() Writer {
 		log.Fatalf("error opening [%s] file", missingCompanyName)
 	}
 
+	alphaKeyErrorsFile, err := os.OpenFile(alphaKeyErrors, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		log.Fatalf("error opening [%s] file", alphaKeyErrors)
+	}
+
 	return &Write{
 		pe:  postErrorFile,
 		ur:  unexpectedResponseFile,
 		mcn: missingCompanyNameFile,
+		ake: alphaKeyErrorsFile,
 	}
 }
 
@@ -78,6 +87,10 @@ func (w *Write) LogUnexpectedResponse(msg string) {
 // LogMissingCompanyName logs an error to the 'missing-company-name' file
 func (w *Write) LogMissingCompanyName(msg string) {
 	writeToFile(w.mcn, missingCompanyName, msg)
+}
+
+func (w *Write) LogAlphaKeyErrors(msg string) {
+	writeToFile(w.ake, alphaKeyErrors, msg)
 }
 
 func writeToFile(connection *os.File, fileName string, msg string) {


### PR DESCRIPTION
Integrate with the Alpha Key Service to add an alpha key to Elastic Search data, ready to be used for querying.

Required for PCI-411