### PR TITLE
Add coverprofile to Makefile test-unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit:
-	go test $(TESTS) -run 'Unit'
+	go test $(TESTS) -run 'Unit' -coverprofile=coverage.out
 
 .PHONY: test-integration
 test-integration:


### PR DESCRIPTION
The test-unit target in the Makefile was missing the correct
 coverprofile config, so Sonar was not seeing any coverage.
Fixed as per best practice.

See https://github.com/companieshouse/styleguides/blob/master/Makefiles/go_makefiles.md