### PR TITLE
GCI-1936: Improvements in avoiding and reporting errors

### DIFF
--- a/companybindex/main.go
+++ b/companybindex/main.go
@@ -121,6 +121,10 @@ func main() {
 			companies[itx] = &result
 		}
 
+		if err := cur.Err(); err != nil {
+			log.Fatalf("error iterating the collection: %s", err)
+		}
+
 		// No results read from iterator. Nothing more to do.
 		if itx == 0 {
 			break

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -77,7 +77,14 @@ func (t *Transform) GetCompanyNames(companies *[]*datastructures.MongoCompany, l
 
 	var companyNames []datastructures.CompanyName
 	for i := 0; i < length; i++ {
-		companyNames = append(companyNames, datastructures.CompanyName{Name: (*companies)[i].Data.CompanyName})
+		mongoCompany := (*companies)[i]
+		if mongoCompany == nil {
+			log.Printf("Missing company element")
+		} else if mongoCompany.Data == nil {
+			log.Printf("Missing company data element")
+		} else {
+			companyNames = append(companyNames, datastructures.CompanyName{Name: (*companies)[i].Data.CompanyName})
+		}
 	}
 
 	return companyNames

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -78,11 +78,12 @@ func (t *Transform) GetCompanyNames(companies *[]*datastructures.MongoCompany, l
 	var companyNames []datastructures.CompanyName
 	for i := 0; i < length; i++ {
 		mongoCompany := (*companies)[i]
-		if mongoCompany == nil {
+		switch {
+		case mongoCompany == nil:
 			log.Printf("Missing company element")
-		} else if mongoCompany.Data == nil {
+		case mongoCompany.Data == nil:
 			log.Printf("Missing company data element")
-		} else {
+		default:
 			companyNames = append(companyNames, datastructures.CompanyName{Name: (*companies)[i].Data.CompanyName})
 		}
 	}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -175,3 +175,103 @@ func TestUnitGetCompanyNames(t *testing.T) {
 		})
 	})
 }
+
+func TestUnitGetCompanyNamesMongoCompanyWithEmptyName(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+
+	mw := write.NewMockWriter(ctrl)
+	mf := format.NewMockFormatter(ctrl)
+	mwf := NewTransformer(mw, mf)
+
+	Convey("Given I have a mongo company with no name", t, func() {
+
+		mongoCompanyWithNoName := datastructures.MongoCompany{
+			Data: &datastructures.MongoData{
+				CompanyName: "",
+			},
+		}
+
+		companies := []*datastructures.MongoCompany{&mongoCompanyWithNoName}
+
+		Convey("When I call GetCompanyNames", func() {
+
+			companyNames := mwf.GetCompanyNames(&companies, 1)
+
+			Convey("Then I expect a CompanyNames to be returned", func() {
+
+				So(len(companyNames), ShouldEqual, 1)
+
+				Convey("And the names should be in order", func() {
+
+					So(companyNames[0].Name, ShouldEqual, "")
+
+				})
+			})
+		})
+	})
+}
+
+func TestUnitGetCompanyNamesNilMongoData(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+
+	mw := write.NewMockWriter(ctrl)
+	mf := format.NewMockFormatter(ctrl)
+	mwf := NewTransformer(mw, mf)
+
+	Convey("Given I have an array of one mongo company with no name", t, func() {
+
+		mc1 := datastructures.MongoCompany{
+			Data: nil,
+		}
+
+		companies := []*datastructures.MongoCompany{&mc1 /*, &mc2, &mc3*/}
+
+		Convey("When I call GetCompanyNames", func() {
+
+			mwf.GetCompanyNames(&companies, 1)
+
+		})
+	})
+}
+
+func TestUnitGetCompanyNamesNilCompanies(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+
+	mw := write.NewMockWriter(ctrl)
+	mf := format.NewMockFormatter(ctrl)
+	mwf := NewTransformer(mw, mf)
+
+	Convey("Given I have an array of one nil mongo company", t, func() {
+
+		var companies []*datastructures.MongoCompany = nil //[]*datastructures.MongoCompany{nil}
+
+		Convey("When I call GetCompanyNames", func() {
+
+			mwf.GetCompanyNames(&companies, 0)
+
+		})
+	})
+}
+
+func TestUnitGetCompanyNamesNilMongoCompany(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+
+	mw := write.NewMockWriter(ctrl)
+	mf := format.NewMockFormatter(ctrl)
+	mwf := NewTransformer(mw, mf)
+
+	Convey("Given I have an array of one nil mongo company", t, func() {
+
+		companies := []*datastructures.MongoCompany{nil}
+
+		Convey("When I call GetCompanyNames", func() {
+
+			mwf.GetCompanyNames(&companies, 1)
+
+		})
+	})
+}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -202,7 +202,7 @@ func TestUnitGetCompanyNamesMongoCompanyWithEmptyName(t *testing.T) {
 
 				So(len(companyNames), ShouldEqual, 1)
 
-				Convey("And the names should be in order", func() {
+				Convey("And the company name should be empty", func() {
 
 					So(companyNames[0].Name, ShouldEqual, "")
 
@@ -230,7 +230,13 @@ func TestUnitGetCompanyNamesNilMongoData(t *testing.T) {
 
 		Convey("When I call GetCompanyNames", func() {
 
-			mwf.GetCompanyNames(&companies, 1)
+			companyNames := mwf.GetCompanyNames(&companies, 1)
+
+			Convey("Then I expect an empty CompanyNames to be returned", func() {
+
+				So(len(companyNames), ShouldEqual, 0)
+
+			})
 
 		})
 	})
@@ -244,13 +250,19 @@ func TestUnitGetCompanyNamesNilCompanies(t *testing.T) {
 	mf := format.NewMockFormatter(ctrl)
 	mwf := NewTransformer(mw, mf)
 
-	Convey("Given I have an array of one nil mongo company", t, func() {
+	Convey("Given I have a nil array of mongo companies", t, func() {
 
 		var companies []*datastructures.MongoCompany = nil //[]*datastructures.MongoCompany{nil}
 
 		Convey("When I call GetCompanyNames", func() {
 
-			mwf.GetCompanyNames(&companies, 0)
+			companyNames := mwf.GetCompanyNames(&companies, 0)
+
+			Convey("Then I expect an empty CompanyNames to be returned", func() {
+
+				So(len(companyNames), ShouldEqual, 0)
+
+			})
 
 		})
 	})
@@ -270,7 +282,13 @@ func TestUnitGetCompanyNamesNilMongoCompany(t *testing.T) {
 
 		Convey("When I call GetCompanyNames", func() {
 
-			mwf.GetCompanyNames(&companies, 1)
+			companyNames := mwf.GetCompanyNames(&companies, 1)
+
+			Convey("Then I expect an empty CompanyNames to be returned", func() {
+
+				So(len(companyNames), ShouldEqual, 0)
+
+			})
 
 		})
 	})


### PR DESCRIPTION
Interim PR raised for visibility - further changes will be made.

* Testing the data loader with staging data has shown 2 areas of behaviour this PR is intended to improve:
  
1. If the database connection dropped midway, the loader stopped reading from the DB but misleadingly reported a successful full load. 
2. Bad companies data (companies with no `data` at all I believe) caused the loader to fail with a segmentation violation error such as `panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1304c85]`

* With the changes in this PR, the behaviour in these 2 cases becomes:

1. the loader exits and reports an error such as `error iterating the collection: connection(mongo-db1-cidev.development.aws.internal:27017[-4]) incomplete read of full message: read tcp 10.172.116.165:49795->10.75.49.84:27017: read: operation timed out`.
2. Such bad companies data is now reported to the console with error messages such as `Missing company element` or `Missing company data element` and the panic described above avoided.

Note that in case (2) however, we then hit other errors resulting from this bad data. For this reason at least, further changes will be made.

