### PR TITLE
adding terraform code

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -1,0 +1,59 @@
+
+data "vault_generic_secret" "stack_secrets" {
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_name}-stack"
+}
+
+data "vault_generic_secret" "service_secrets" {
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_name}-stack/${local.service_name}"
+}
+
+data "aws_kms_key" "kms_key" {
+  key_id = local.kms_alias
+}
+
+data "aws_vpc" "vpc" {
+  filter {
+    name   = "tag:Name"
+    values = [local.vpc_name]
+  }
+}
+
+#Get application subnet IDs
+data "aws_subnets" "application" {
+  filter {
+    name   = "tag:Name"
+    values = [local.application_subnet_pattern]
+  }
+}
+
+data "aws_ecs_cluster" "ecs_cluster" {
+  cluster_name = "${local.name_prefix}-cluster"
+}
+data "aws_iam_role" "ecs_cluster_iam_role" {
+  name = "${local.name_prefix}-ecs-task-execution-role"
+}
+
+# retrieve all secrets for this stack using the stack path
+data "aws_ssm_parameters_by_path" "secrets" {
+  path = "/${local.name_prefix}"
+}
+# create a list of secrets names to retrieve them in a nicer format and lookup each secret by name
+data "aws_ssm_parameter" "secret" {
+  for_each = toset(data.aws_ssm_parameters_by_path.secrets.names)
+  name     = each.key
+}
+
+# retrieve all global secrets for this env using global path
+data "aws_ssm_parameters_by_path" "global_secrets" {
+  path = "/${local.global_prefix}"
+}
+# create a list of secrets names to retrieve them in a nicer format and lookup each secret by name
+data "aws_ssm_parameter" "global_secret" {
+  for_each = toset(data.aws_ssm_parameters_by_path.global_secrets.names)
+  name     = each.key
+}
+
+// --- s3 bucket for shared services config ---
+data "vault_generic_secret" "shared_s3" {
+  path = "aws-accounts/shared-services/s3"
+}

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -1,0 +1,62 @@
+# Define all hardcoded local variable and local variables looked up from data resources
+locals {
+  stack_name                  = "search-service" # this must match the stack name the service deploys into
+  name_prefix                 = "${local.stack_name}-${var.environment}"
+  global_prefix               = "global-${var.environment}"
+  service_name                = "elasticsearch-data-loader"
+  container_port              = "8080"
+  docker_repo                 = "elasticsearch-data-loader"
+  kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
+  vpc_name                    = local.stack_secrets["vpc_name"]
+  app_environment_filename    = "elasticsearch-data-loader.env"
+  use_set_environment_files   = var.use_set_environment_files
+  application_subnet_ids      = data.aws_subnets.application.ids
+  application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
+  # Set this to true if secrets are required and need to be retrieved from vault
+  stack_secrets = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
+  service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)
+
+  # create a map of secret name => secret arn to pass into ecs service module
+  # using the trimprefix function to remove the prefixed path from the secret name
+  secrets_arn_map = {
+    for sec in data.aws_ssm_parameter.secret :
+    trimprefix(sec.name, "/${local.name_prefix}/") => sec.arn
+  }
+
+  global_secrets_arn_map = {
+    for sec in data.aws_ssm_parameter.global_secret :
+    trimprefix(sec.name, "/${local.global_prefix}/") => sec.arn
+  }
+
+  global_secret_list = flatten([for key, value in local.global_secrets_arn_map :
+    { name = upper(key), valueFrom = value }
+  ])
+
+  ssm_global_version_map = [
+    for sec in data.aws_ssm_parameter.global_secret : {
+      name = "GLOBAL_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", value = sec.version
+    }
+  ]
+
+  service_secrets_arn_map = {
+    for sec in module.secrets.secrets:
+      trimprefix(sec.name, "/${local.service_name}-${var.environment}/") => sec.arn
+  }
+
+  service_secret_list = flatten([for key, value in local.service_secrets_arn_map :
+    { name = upper(key), valueFrom = value }
+  ])
+
+  ssm_service_version_map = [
+    for sec in module.secrets.secrets : {
+      name = "${replace(upper(local.service_name), "-", "_")}_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", value = sec.version
+    }
+  ]
+
+  # secrets to go in list
+  task_secrets = concat(local.service_secret_list,local.global_secret_list)
+
+  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map,[
+    { name : "PORT", value : local.container_port }
+  ])
+}

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -32,7 +32,7 @@ module "ecs-service" {
   # Docker container details
   docker_registry   = var.docker_registry
   docker_repo       = local.docker_repo
-  container_version = var.elasticsearch-data-loader_version
+  container_version = var.elasticsearch_data_loader_version
   container_port = local.container_port
 
   # Service configuration

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -1,0 +1,77 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+terraform {
+  required_version = ">= 1.3, < 2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.54.0, < 6.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 4.0, < 5.0"
+    }
+  }
+  backend "s3" {}
+}
+
+module "ecs-service" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.334"
+
+  # Environmental configuration
+  environment    = var.environment
+  aws_region     = var.aws_region
+  aws_profile    = var.aws_profile
+  vpc_id         = data.aws_vpc.vpc.id
+  ecs_cluster_id = data.aws_ecs_cluster.ecs_cluster.id
+  task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  batch_service = true
+
+  # Docker container details
+  docker_registry   = var.docker_registry
+  docker_repo       = local.docker_repo
+  container_version = var.elasticsearch-data-loader_version
+  container_port = local.container_port
+
+  # Service configuration
+  service_name = local.service_name
+  name_prefix = local.name_prefix
+
+  # Service performance and scaling configs
+  desired_task_count                   = var.desired_task_count
+  max_task_count                       = var.max_task_count
+  min_task_count                       = var.min_task_count
+  required_cpus                        = var.required_cpus
+  required_memory                      = var.required_memory
+  service_autoscale_enabled            = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
+  service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
+  service_scaledown_schedule           = var.service_scaledown_schedule
+  service_scaleup_schedule             = var.service_scaleup_schedule
+  use_capacity_provider                = var.use_capacity_provider
+  use_fargate                          = var.use_fargate
+  fargate_subnets = local.application_subnet_ids
+
+  # Cloudwatch
+  cloudwatch_alarms_enabled = var.cloudwatch_alarms_enabled
+
+  # Service environment variable and secret configs
+  task_environment         = local.task_environment
+  task_secrets             = local.task_secrets
+  app_environment_filename = local.app_environment_filename
+  use_set_environment_files = local.use_set_environment_files
+
+  create_service_dashboard = var.create_service_dashboard
+}
+
+module "secrets" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.334"
+
+  name_prefix = "${local.service_name}-${var.environment}"
+  environment = var.environment
+  kms_key_id  = data.aws_kms_key.kms_key.id
+  secrets     = nonsensitive(local.service_secrets)
+}

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -1,0 +1,17 @@
+environment = "cidev"
+aws_profile = "development-eu-west-2"
+
+# service configs
+use_set_environment_files = true
+
+# default allocation
+required_cpus = 16384
+required_memory = 32768
+
+# scaling configs default
+desired_task_count = 0
+min_task_count = 0
+max_task_count = 1
+
+# Scheduled scaling of tasks
+service_autoscale_enabled  = false

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -1,0 +1,14 @@
+environment = "live"
+aws_profile = "live-eu-west-2"
+
+# service configs
+use_set_environment_files = true
+
+# default allocation
+required_cpus = 16384
+required_memory = 32768
+
+# scaling configs default
+desired_task_count = 0
+min_task_count = 0
+max_task_count = 1

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -1,0 +1,18 @@
+environment = "staging"
+aws_profile = "staging-eu-west-2"
+
+# service configs
+use_set_environment_files = true
+log_level = "trace"
+
+# default allocation
+required_cpus = 16384
+required_memory = 32768
+
+# scaling configs default
+desired_task_count = 0
+min_task_count = 0
+max_task_count = 1
+
+# Scheduled scaling of tasks
+service_autoscale_enabled  = false

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -1,0 +1,137 @@
+# ------------------------------------------------------------------------------
+# Environment
+# ------------------------------------------------------------------------------
+variable "environment" {
+  type        = string
+  description = "The environment name, defined in environments vars."
+}
+variable "aws_region" {
+  default     = "eu-west-2"
+  type        = string
+  description = "The AWS region for deployment."
+}
+variable "aws_profile" {
+  default     = "development-eu-west-2"
+  type        = string
+  description = "The AWS profile to use for deployment."
+}
+
+# ------------------------------------------------------------------------------
+# Docker Container
+# ------------------------------------------------------------------------------
+variable "docker_registry" {
+  type        = string
+  description = "The FQDN of the Docker registry."
+}
+
+# ------------------------------------------------------------------------------
+# Service performance and scaling configs
+# ------------------------------------------------------------------------------
+variable "desired_task_count" {
+  type = number
+  description = "The desired ECS task count for this service"
+  default = 0 # defaulted low for dev environments, override for production
+}
+variable "min_task_count" {
+  default     = 0
+  type        = number
+  description = "The minimum number of tasks for this service."
+}
+variable "required_cpus" {
+  type = number
+  description = "The required cpu resource for this service. 1024 here is 1 vCPU"
+  default = 256 # defaulted low for dev environments, override for production
+}
+variable "required_memory" {
+  type = number
+  description = "The required memory for this service"
+  default = 512 # defaulted low for node service in dev environments, override for production
+}
+
+variable "max_task_count" {
+  type        = number
+  description = "The maximum number of tasks for this service."
+  default     = 1
+}
+
+variable "use_fargate" {
+  type        = bool
+  description = "If true, sets the required capabilities for all containers in the task definition to use FARGATE, false uses EC2"
+  default     = true
+}
+variable "use_capacity_provider" {
+  type        = bool
+  description = "Whether to use a capacity provider instead of setting a launch type for the service"
+  default     = true
+}
+variable "service_autoscale_enabled" {
+  type        = bool
+  description = "Whether to enable service autoscaling, including scheduled autoscaling"
+  default     = false
+}
+variable "service_autoscale_target_value_cpu" {
+  type        = number
+  description = "Target CPU percentage for the ECS Service to autoscale on"
+  default     = 80 # 100 disables autoscaling using CPU as a metric
+}
+variable "service_scaledown_schedule" {
+  type        = string
+  description = "The schedule to use when scaling down the number of tasks to zero."
+  # Typically used to stop all tasks in a service to save resource costs overnight.
+  # E.g. a value of '55 19 * * ? *' would be Mon-Sun 7:55pm.  An empty string indicates that no schedule should be created.
+
+  default     = ""
+}
+variable "service_scaleup_schedule" {
+  type        = string
+  description = "The schedule to use when scaling up the number of tasks to their normal desired level."
+  # Typically used to start all tasks in a service after it has been shutdown overnight.
+  # E.g. a value of '5 6 * * ? *' would be Mon-Sun 6:05am.  An empty string indicates that no schedule should be created.
+
+  default     = ""
+}
+variable "service_autoscale_scale_in_cooldown" {
+  default     = 300
+  description = "Cooldown in seconds for ECS Service scale in"
+  type        = number
+}
+variable "service_autoscale_scale_out_cooldown" {
+  default     = 120
+  description = "Cooldown in seconds for ECS Service scale out"
+  type        = number
+}
+
+# ----------------------------------------------------------------------
+# Cloudwatch alerts
+# ----------------------------------------------------------------------
+variable "cloudwatch_alarms_enabled" {
+  description = "Whether to create a standard set of cloudwatch alarms for the service.  Requires an SNS topic to have already been created for the stack."
+  type        = bool
+  default     = false
+}
+
+# ------------------------------------------------------------------------------
+# Service environment variable configs
+# ------------------------------------------------------------------------------
+variable "ssm_version_prefix" {
+  type        = string
+  description = "String to use as a prefix to the names of the variables containing variables and secrets version."
+  default     = "SSM_VERSION_"
+}
+
+variable "use_set_environment_files" {
+  type        = bool
+  default     = false
+  description = "Toggle default global and shared  environment files"
+}
+
+variable "elasticsearch-data-loader_version" {
+  type        = string
+  description = "The version of the primary-search-api container to run."
+}
+
+variable "create_service_dashboard" {
+  default     = true
+  description = "Defines whether a CloudWatch dashboard is created for the default ECS service (true) or not (false)"
+  type        = bool
+}

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -125,9 +125,9 @@ variable "use_set_environment_files" {
   description = "Toggle default global and shared  environment files"
 }
 
-variable "elasticsearch-data-loader_version" {
+variable "elasticsearch_data_loader_version" {
   type        = string
-  description = "The version of the primary-search-api container to run."
+  description = "The version of the elasticsearch-data-loader container to run."
 }
 
 variable "create_service_dashboard" {

--- a/terraform/groups/ecs-service/vault-providers/approle
+++ b/terraform/groups/ecs-service/vault-providers/approle
@@ -1,0 +1,20 @@
+variable "hashicorp_vault_role_id" {
+  description = "The role identifier used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+variable "hashicorp_vault_secret_id" {
+  description = "The secret identifier used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/approle/login"
+
+    parameters = {
+      role_id   = var.hashicorp_vault_role_id
+      secret_id = var.hashicorp_vault_secret_id
+    }
+  }
+}

--- a/terraform/groups/ecs-service/vault-providers/token
+++ b/terraform/groups/ecs-service/vault-providers/token
@@ -1,0 +1,5 @@
+provider "vault" {
+    # Credentials read from the environment variables:
+    #   ${VAULT_ADDR}
+    #   ${VAULT_TOKEN}
+}

--- a/terraform/groups/ecs-service/vault-providers/userpass
+++ b/terraform/groups/ecs-service/vault-providers/userpass
@@ -1,0 +1,19 @@
+variable "hashicorp_vault_username" {
+  description = "The username used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+variable "hashicorp_vault_password" {
+  description = "The password used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.hashicorp_vault_username}"
+
+    parameters = {
+      password = var.hashicorp_vault_password
+    }
+  }
+}

--- a/terraform/groups/ecs-service/vault.tf
+++ b/terraform/groups/ecs-service/vault.tf
@@ -1,0 +1,19 @@
+variable "hashicorp_vault_username" {
+  description = "The username used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+variable "hashicorp_vault_password" {
+  description = "The password used when retrieving configuration from Hashicorp Vault"
+  type = string
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.hashicorp_vault_username}"
+
+    parameters = {
+      password = var.hashicorp_vault_password
+    }
+  }
+}

--- a/terraform/groups/ecs-service/version
+++ b/terraform/groups/ecs-service/version
@@ -1,0 +1,1 @@
+ecs-service-1.0


### PR DESCRIPTION
This change adds Terraform infrastructure code to deploy `elasticsearch-data-loader` as an ECS service using our shared `ecs-service` and `secrets` modules.  
It standardizes environment-specific deployment inputs and wires in Vault/SSM-based configuration and secret discovery.

## What changed

- Added ECS service Terraform module scaffolding under `terraform/groups/ecs-service/`.
- Added provider and module wiring in `terraform/groups/ecs-service/main.tf`:
  - `module "ecs-service"` for ECS task/service deployment
  - `module "secrets"` for service secret management
- Added data lookups in `terraform/groups/ecs-service/data.tf` for:
  - stack/service secrets from Vault
  - VPC/subnets/KMS/ECS cluster/task execution role from AWS
  - global and service SSM parameters
- Added service locals in `terraform/groups/ecs-service/locals.tf`:
  - naming/prefix conventions
  - task environment variables
  - task secret mapping and SSM version exposure
- Added module input variables in `terraform/groups/ecs-service/variables.tf`.
- Added Vault provider configuration in `terraform/groups/ecs-service/vault.tf`.
- Added environment profile var files:
  - `terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars`
  - `terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars`
  - `terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars`
- Added vault provider helper files and module `version` file.
